### PR TITLE
Fix carousel issue with image height on iOS

### DIFF
--- a/views/pages/widget-carousel.hbs
+++ b/views/pages/widget-carousel.hbs
@@ -14,7 +14,7 @@
                 <div class="shrink-0 bg-white rounded-xl shadow-md overflow-hidden w-full max-w-lg">
                     <div class="flex h-full flex-col md:flex-row">
                         <div class="md:shrink-0">
-                            <a href="{{ add_utm this.data.eventUrl }}" target="_blank"><img class="w-full md:w-48 object-cover h-full" src="{{ this.data.imageUrl }}" alt="{{ this.data.title }}"></a>
+                            <a href="{{ add_utm this.data.eventUrl }}" target="_blank"><img class="w-full md:w-48 object-cover md:h-full" src="{{ this.data.imageUrl }}" alt="{{ this.data.title }}"></a>
                         </div>
                         <div class="p-4 md:p-8">
                             <div class="uppercase tracking-wide text-sm text-blue-500 font-semibold"><a href="{{ add_utm this.data.eventUrl }}" target="_blank">{{ to_local_date this.data.dateTime }}</a></div>


### PR DESCRIPTION
Changed the image height to be under the medium breakpoint.


![image](https://github.com/TampaDevs/events.api.tampa.dev/assets/10530584/5d7f85bf-bca0-4c83-9fce-da9735268fc4)


closes: https://github.com/TampaDevs/tampa.dev/issues/3

