### PR TITLE
Add within_hours and within_days query options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,38 @@ export async function filterEventData(event_data, params) {
         }, {});
     }
 
+    if (params.within_hours) {
+        const withinHours = parseInt(params.within_hours);
+        for (const [_, value] of Object.entries(event_data)) {
+            const upcomingEvents = value.eventSearch.edges.filter(edge => {
+                const eventDateTimeStr = edge.node.dateTime;
+                const eventDateTime = new Date(eventDateTimeStr);
+                const now = new Date();
+                const timeDifference = eventDateTime - now;
+                const hoursInMs = withinHours * 60 * 60 * 1000;
+                return timeDifference > 0 && timeDifference < hoursInMs;
+            });
+            value.eventSearch.edges = upcomingEvents;
+            value.eventSearch.count = upcomingEvents.length;
+        }
+    }
+
+    if (params.within_days) {
+        const withinDays = parseInt(params.within_days);
+        for (const [_, value] of Object.entries(event_data)) {
+            const upcomingEvents = value.eventSearch.edges.filter(edge => {
+                const eventDateTimeStr = edge.node.dateTime;
+                const eventDateTime = new Date(eventDateTimeStr);
+                const now = new Date();
+                const timeDifference = eventDateTime - now;
+                const daysInMs = withinDays * 24 * 60 * 60 * 1000;
+                return timeDifference > 0 && timeDifference < daysInMs;
+            });
+            value.eventSearch.edges = upcomingEvents;
+            value.eventSearch.count = upcomingEvents.length;
+        }
+    }
+
     return event_data;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ export default {
             const url = new URL(request.url);
             const params = await util.parseQueryParams(url);
 
+            if (url.pathname === '/favicon.ico') {
+                return new Response();
+            }
+
             const eventData = await util.filterEventData(JSON.parse(await env.kv.get("event_data")), params)
 
             if (url.pathname == '/rss' || url.pathname == '/feed') {


### PR DESCRIPTION
Addresses https://github.com/TampaDevs/events.api.tampa.dev/pull/57#issuecomment-2254615616

This PR adds `within_hours` and `within_days` query options to the API, so that clients may request events that are `X` hours out or `X` days out from now.

## Notes

I was tempted to abstract the filtering logic into a partial function, but opted to duplicate the code for simplicity.

Also, the browser was requesting a favicon, which was messing with development. I put a check in at the top of the request loop to return, but I'm not sure if it's actually being handled property or not.